### PR TITLE
[feat] 공통 응답처리 및 예외처리 구현

### DIFF
--- a/hotketok-common-service/build.gradle
+++ b/hotketok-common-service/build.gradle
@@ -20,6 +20,14 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/hotketok-common-service/build.gradle
+++ b/hotketok-common-service/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+	id 'java'
+	id 'org.springframework.boot' version '3.5.5'
+	id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.hotketok'
+version = '0.0.1-SNAPSHOT'
+description = 'Demo project for Spring Boot'
+
+java {
+	toolchain {
+		languageVersion = JavaLanguageVersion.of(17)
+	}
+}
+
+repositories {
+	mavenCentral()
+}
+
+dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-web'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+bootJar {
+	enabled = false
+}
+
+jar {
+	enabled = true
+}
+
+tasks.named('test') {
+	useJUnitPlatform()
+}

--- a/hotketok-common-service/build.gradle
+++ b/hotketok-common-service/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'java'
+	id 'java-library'
 	id 'org.springframework.boot' version '3.5.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 }
@@ -19,14 +19,14 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+	api 'org.springframework.boot:spring-boot-starter-web'
 
 	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	// validation
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	api 'org.springframework.boot:spring-boot-starter-validation'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
@@ -36,9 +36,7 @@ bootJar {
 	enabled = false
 }
 
-jar {
-	enabled = true
-}
+jar { enabled = true }
 
 tasks.named('test') {
 	useJUnitPlatform()

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/HotketokCommonServiceApplication.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/HotketokCommonServiceApplication.java
@@ -1,0 +1,13 @@
+package com.hotketok.hotketokcommonservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class HotketokCommonServiceApplication {
+
+	public static void main(String[] args) {
+		SpringApplication.run(HotketokCommonServiceApplication.class, args);
+	}
+
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/ErrorResponse.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/ErrorResponse.java
@@ -1,0 +1,10 @@
+package com.hotketok.hotketokcommonservice.error;
+
+public record ErrorResponse(
+        String errorClassName,
+        String message
+) {
+    public static ErrorResponse of(String errorClassName, String message) {
+        return new ErrorResponse(errorClassName, message);
+    }
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/GlobalExceptionHandler.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/GlobalExceptionHandler.java
@@ -1,0 +1,146 @@
+package com.hotketok.hotketokcommonservice.error;
+
+import com.hotketok.hotketokcommonservice.error.exception.CustomException;
+import com.hotketok.hotketokcommonservice.error.exception.ErrorCode;
+import com.hotketok.hotketokcommonservice.error.exception.GlobalErrorCode;
+import com.hotketok.hotketokcommonservice.response.GlobalResponse;
+import jakarta.validation.ConstraintViolationException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+        ErrorResponse errorResponse =
+                ErrorResponse.of(ex.getClass().getSimpleName(), ex.getMessage());
+        return super.handleExceptionInternal(ex, errorResponse, headers, statusCode, request);
+    }
+
+    /**
+     * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다. HttpMessageConverter 에서 등록한
+     * HttpMessageConverter binding 못할경우 발생 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+     */
+    @SneakyThrows
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        log.error("MethodArgumentNotValidException : {}", e.getMessage(), e);
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorMessage);
+        GlobalResponse response = GlobalResponse.fail(status.value(), errorResponse);
+        return ResponseEntity.status(status).body(response);
+    }
+
+    /** Request Param Validation 예외 처리 */
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<GlobalResponse> handleConstraintViolationException(
+            ConstraintViolationException e) {
+        log.error("ConstraintViolationException : {}", e.getMessage(), e);
+
+        Map<String, Object> bindingErrors = new HashMap<>();
+        e.getConstraintViolations()
+                .forEach(
+                        constraintViolation -> {
+                            List<String> propertyPath =
+                                    List.of(
+                                            constraintViolation
+                                                    .getPropertyPath()
+                                                    .toString()
+                                                    .split("\\."));
+                            String path =
+                                    propertyPath.stream()
+                                            .skip(propertyPath.size() - 1L)
+                                            .findFirst()
+                                            .orElse(null);
+                            bindingErrors.put(path, constraintViolation.getMessage());
+                        });
+
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), bindingErrors.toString());
+        final GlobalResponse response =
+                GlobalResponse.fail(HttpStatus.BAD_REQUEST.value(), errorResponse);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(response);
+    }
+
+    /** PathVariable, RequestParam, RequestHeader, RequestBody 에서 타입이 일치하지 않을 경우 발생 */
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    protected ResponseEntity<GlobalResponse> handleMethodArgumentTypeMismatchException(
+            MethodArgumentTypeMismatchException e) {
+        log.error("MethodArgumentTypeMismatchException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = GlobalErrorCode.METHOD_ARGUMENT_TYPE_MISMATCH;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getStatus().value(), errorResponse);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** 지원하지 않은 HTTP method 호출 할 경우 발생 */
+    @Override
+    protected ResponseEntity<Object> handleHttpRequestMethodNotSupported(
+            HttpRequestMethodNotSupportedException e,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        log.error("HttpRequestMethodNotSupportedException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = GlobalErrorCode.METHOD_NOT_ALLOWED;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getStatus().value(), errorResponse);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** CustomException 예외 처리 */
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<GlobalResponse> handleCustomException(CustomException e) {
+        log.error("CustomException : {}", e.getMessage(), e);
+        final ErrorCode errorCode = e.getErrorCode();
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(errorCode.getErrorName(), errorCode.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(errorCode.getStatus().value(), errorResponse);
+        return ResponseEntity.status(errorCode.getStatus()).body(response);
+    }
+
+    /** 500번대 에러 처리 */
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<GlobalResponse> handleException(Exception e) {
+        log.error("Internal Server Error : {}", e.getMessage(), e);
+        final ErrorCode internalServerError = GlobalErrorCode.INTERNAL_SERVER_ERROR;
+        final ErrorResponse errorResponse =
+                ErrorResponse.of(e.getClass().getSimpleName(), internalServerError.getMessage());
+        final GlobalResponse response =
+                GlobalResponse.fail(internalServerError.getStatus().value(), errorResponse);
+        return ResponseEntity.status(internalServerError.getStatus()).body(response);
+    }
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/GlobalExceptionHandler.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/GlobalExceptionHandler.java
@@ -25,8 +25,7 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 
 
 @Slf4j
-@RestControllerAdvice
-@RequiredArgsConstructor
+@RestControllerAdvice(basePackages = "com.hotketok")
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/CustomException.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/CustomException.java
@@ -1,0 +1,13 @@
+package com.hotketok.hotketokcommonservice.error.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/ErrorCode.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.hotketok.hotketokcommonservice.error.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getStatus();
+
+    String getMessage();
+
+    default String getErrorName() {
+        return this.toString();
+    }
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/GlobalErrorCode.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/error/exception/GlobalErrorCode.java
@@ -1,0 +1,24 @@
+package com.hotketok.hotketokcommonservice.error.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    BAD_REQUEST(HttpStatus.BAD_REQUEST,  "잘못된 요청입니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED,  "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN,  "금지된 요청입니다."),
+    INVALID_REQUEST_INFO(HttpStatus.BAD_REQUEST,  "요청된 정보가 올바르지 않습니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "유효성 검증에 실패했습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST,  "유효하지 않은 파라미터입니다."),
+    METHOD_ARGUMENT_TYPE_MISMATCH(HttpStatus.BAD_REQUEST,"Enum Type이 일치하지 않아 Binding에 실패하였습니다."),
+    METHOD_NOT_ALLOWED(HttpStatus.METHOD_NOT_ALLOWED,"지원하지 않는 HTTP method 입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,  "서버 에러, 관리자에게 문의 바랍니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponse.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponse.java
@@ -1,10 +1,14 @@
 package com.hotketok.hotketokcommonservice.response;
 
+import com.hotketok.hotketokcommonservice.error.ErrorResponse;
+
 import java.time.LocalDateTime;
 
 public record GlobalResponse(boolean success, int status, Object data, LocalDateTime timestamp) {
     public static GlobalResponse success(int status, Object data) {
         return new GlobalResponse(true, status, data, LocalDateTime.now());
     }
-
+    public static GlobalResponse fail(int status, ErrorResponse errorResponse) {
+        return new GlobalResponse(false, status, errorResponse, LocalDateTime.now());
+    }
 }

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponse.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponse.java
@@ -1,0 +1,10 @@
+package com.hotketok.hotketokcommonservice.response;
+
+import java.time.LocalDateTime;
+
+public record GlobalResponse(boolean success, int status, Object data, LocalDateTime timestamp) {
+    public static GlobalResponse success(int status, Object data) {
+        return new GlobalResponse(true, status, data, LocalDateTime.now());
+    }
+
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponseAdvice.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponseAdvice.java
@@ -1,0 +1,50 @@
+package com.hotketok.hotketokcommonservice.response;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.http.server.ServletServerHttpResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@RestControllerAdvice(basePackages = "com.hotketok")
+public class GlobalResponseAdvice implements ResponseBodyAdvice {
+    @Override
+    public boolean supports(MethodParameter returnType, Class converterType) {
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(
+            Object body,
+            MethodParameter returnType,
+            MediaType selectedContentType,
+            Class selectedConverterType,
+            ServerHttpRequest request,
+            ServerHttpResponse response) {
+
+        HttpServletResponse servletResponse =
+                ((ServletServerHttpResponse) response).getServletResponse();
+        // Spring의 ServerHttpResponse는 추상적이기 때문에,
+        //실제 서블릿 응답 객체를 얻으려면 캐스팅이 필요
+
+        int status = servletResponse.getStatus();
+        // 응답의 HTTP 상태 코드를 가져옴
+
+        HttpStatus resolve = HttpStatus.resolve(status);
+        // 숫자 상태 코드 → HttpStatus Enum으로 변환 (HttpStatus.valueOf(status)의 안전한 버전)
+
+        if (resolve == null || body instanceof String) {
+            return body;
+        } // 1. 상태 코드가 잘못됐거나, body가 String이면 응답을 가공하지 않음
+
+        if (resolve.is2xxSuccessful()) {
+            return GlobalResponse.success(status, body);
+        } // 2. 2xx 응답이면 GlobalResponse로 감싸서 응답
+
+        return body;
+    }
+}

--- a/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponseAdvice.java
+++ b/hotketok-common-service/src/main/java/com/hotketok/hotketokcommonservice/response/GlobalResponseAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.http.server.ServletServerHttpResponse;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
 
-@RestControllerAdvice(basePackages = "com.hotketok")
+@RestControllerAdvice(basePackages = "com.hotketok.externalApi")
 public class GlobalResponseAdvice implements ResponseBodyAdvice {
     @Override
     public boolean supports(MethodParameter returnType, Class converterType) {

--- a/hotketok-common-service/src/test/java/com/hotketok/hotketokcommonservice/HotketokCommonServiceApplicationTests.java
+++ b/hotketok-common-service/src/test/java/com/hotketok/hotketokcommonservice/HotketokCommonServiceApplicationTests.java
@@ -1,0 +1,13 @@
+package com.hotketok.hotketokcommonservice;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class HotketokCommonServiceApplicationTests {
+
+	@Test
+	void contextLoads() {
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,7 @@
 rootProject.name = 'hotketok'
 
 include(
+        "hotketok-common-service",
         "hotketok-config-server",
         "hotketok-eureka-server"
 )


### PR DESCRIPTION
## 🌱 관련 이슈

- close #7 

---
## 📌 작업 내용 및 특이사항

- 마이크로서비스 전반에 처리할 common-service 모듈 생성했습니다. 해당 서비스를 이용하기 위해 아래에 적힌 의존성을 build.gradle에 추가해주시면 됩니다.  
- 모든 서비스에서 API 응답 포맷을 통일하기 위해 공통 응답 어드바이스 생성했습니다. ( 컨트롤러에서 ResponseEntity로 처리안하고 바로 DTO로 반환해도 아래와 같이 응답합니다. )
- 전역 예외 처리용 GlobalExceptionHandler을 생성하였습니다. (각각 Validation, CustomException, 500 에러 등등 모든 에러에 대해 처리했습니다.)
- ErrorCode를 인터페이스로 구현하였으니 각 서비스에서 아래 에러코드 양식을 참고해서 구현해주시면 됩니다.

---
## 📚 참고사항
- 각 마이크로서비스에 추가해야될 의존성
<pre>
<code>
implementation project(':hotketok-common-service')
</code>
</pre>
</br>

- 응답 구조
<pre>
<code>
{
   "success": true,
   "status": 200,
   "data": {
      exampleKey : "exampleValue"
   },
   "timestamp": "2025-09-15T11:30:42.12461"
}
</code>
</pre>
</br>

-  각 마이크로서비스에서 도메인 별 에러코드 양식
<pre>
<code>
@Getter
@AllArgsConstructor
public enum ExampleErrorCode implements ErrorCode {
    EXAMPLE_NOT_FOUND(HttpStatus.NOT_FOUND, "__를 찾을 수 없습니다."),
    EXAMPLE2_NOT_FOUND(HttpStatus.NOT_FOUND, "__를 찾을 수 없습니다.")
    ;

    private final HttpStatus httpStatus;
    private final String message;
}
</code>
</pre>