### PR TITLE
[fix] 각 마이크로서비스에서 현재 사용자Id를 헤더에서 가져오도록 수정 및 전체 마이크로서비스 포트번호 수정

### DIFF
--- a/hotketok-api-gateway/src/main/resources/application-local.yml
+++ b/hotketok-api-gateway/src/main/resources/application-local.yml
@@ -28,19 +28,6 @@ spring:
                       - OWNER
                       - TENANT
 
-            - id: example-service
-              uri: lb://requestform-service
-              predicates:
-                - Path=/api/example-service/**
-                - Method=GET,POST,PUT,DELETE
-              filters:
-                - JwtAuthFilter
-                - name: RoleFilter
-                  args:
-                    allowedRoles:
-                      - OWNER
-                      - TENANT
-
             - id: chatting-service
               uri: lb://chatting-service
               predicates:
@@ -65,6 +52,35 @@ spring:
                 - name: RoleFilter
                   args:
                     allowedRoles:
+                      - OWNER
+                      - TENANT
+
+            - id: house-service
+              uri: lb://infra-service
+              predicates:
+                - Path=/api/house-service/**
+                - Method=GET,POST,PUT,DELETE
+              filters:
+                - JwtAuthFilter
+                - name: RoleFilter
+                  args:
+                    allowedRoles:
+                      - NONE
+                      - OWNER
+                      - TENANT
+                      - VENDOR
+
+            - id: user-service
+              uri: lb://user-service
+              predicates:
+                - Path=/api/user-service/**
+                - Method=GET,POST,PUT,DELETE
+              filters:
+                - JwtAuthFilter
+                - name: RoleFilter
+                  args:
+                    allowedRoles:
+                      - NONE
                       - OWNER
                       - TENANT
                       - VENDOR

--- a/hotketok-auth-service/src/main/resources/application-local.yml
+++ b/hotketok-auth-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8085
+  port: 8087
 
 spring:
   application:
@@ -39,4 +39,4 @@ coolsms:
 
 client:
   user-service:
-    url: http://localhost:8084 # infra-service의 주소
+    url: http://localhost:8088 # infra-service의 주소

--- a/hotketok-chatting-service/src/main/java/com/hotketok/externalApi/ChatRoomController.java
+++ b/hotketok-chatting-service/src/main/java/com/hotketok/externalApi/ChatRoomController.java
@@ -26,23 +26,22 @@ public class ChatRoomController {
 
     // 특정 유저의 채팅방 목록 조회
     @GetMapping("/users/rooms")
-    public List<ChatRoomResponse> findChatRoomsByUserId() {
-        Long userId = 101L; // 임시 데이터
+    public List<ChatRoomResponse> findChatRoomsByUserId(@RequestHeader("userId") Long userId) {
         return chatService.findChatRoomsByUserId(userId);
     }
 
     // 채팅방 삭제
     @DeleteMapping("/rooms")
-    public ResponseEntity<Void> deleteChatRoom(@RequestParam Long roomId) {
-        Long userId = 101L; // 임시 데이터
+    public ResponseEntity<Void> deleteChatRoom(@RequestHeader("userId") Long userId,
+                                               @RequestParam Long roomId) {
         chatService.deleteChatRoom(userId, roomId);
         return ResponseEntity.noContent().build(); // 성공적으로 삭제되었으면 204 No Content
     }
 
     // 특정 채팅방의 채팅 내용 조회
     @GetMapping("/rooms/messages")
-    public List<ChatMessageResponse> findMessagesByRoomId(@RequestParam Long roomId) {
-        Long userId = 101L; // 임시 데이터
+    public List<ChatMessageResponse> findMessagesByRoomId(@RequestHeader("userId") Long userId,
+                                                          @RequestParam Long roomId) {
         return chatService.findMessagesByRoomId(userId, roomId);
     }
 }

--- a/hotketok-chatting-service/src/main/resources/application-local.yml
+++ b/hotketok-chatting-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8086
+  port: 8096
 
 spring:
   application:
@@ -12,17 +12,16 @@ spring:
       path: /h2-console
 
   # ===== 데이터소스 =====
-#  datasource:
-#    url: jdbc:h2:tcp://localhost/~/chatting
-#    username: sa
-#    password:
-#    driver-class-name: org.h2.Driver
-
   datasource:
-    url: jdbc:h2:file:~/chatting
+    url: jdbc:h2:tcp://localhost/~/chatting
     username: sa
     password:
     driver-class-name: org.h2.Driver
+  #datasource:
+  #  url: jdbc:h2:file:~/chatting
+  #  username: sa
+  #  password:
+  #  driver-class-name: org.h2.Driver
 
   # ===== JPA =====
   jpa:

--- a/hotketok-house-service/src/main/java/com/hotketok/externalApi/HouseController.java
+++ b/hotketok-house-service/src/main/java/com/hotketok/externalApi/HouseController.java
@@ -20,9 +20,9 @@ public class HouseController {
 
     // 집주인 집 등록
     @PostMapping(value = "/register", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-    public RegisterHouseResponse registerHouse(/*@RequestHeader("userId")*/ @RequestParam Long ownerId,
-                                                                            @RequestPart("file") MultipartFile file,
-                                                                            @RequestPart("data") RegisterHouseRequest request) {
+    public RegisterHouseResponse registerHouse(@RequestHeader("userId") Long ownerId,
+                                               @RequestPart("file") MultipartFile file,
+                                               @RequestPart("data") RegisterHouseRequest request) {
         return houseService.registerHouse(ownerId, file, request);
     }
 
@@ -42,21 +42,21 @@ public class HouseController {
 
     // 입주민 요청 (주소/동/호수 기반)
     @PostMapping("/tenant-request")
-    public RegisterTenantResponse registerTenant(/*@RequestHeader("userId")*/ @RequestParam Long tenantId,
+    public RegisterTenantResponse registerTenant(@RequestHeader("userId") Long tenantId,
                                                  @RequestBody RegisterTenantRequest request) {
         return houseService.registerTenant(tenantId,request);
     }
 
     // 집주인 요청 목록
     @GetMapping("/tenant-requestList")
-    public List<TenantRequestResponse> getTenantRequestList(/*@RequestHeader("userId")*/ @RequestParam Long ownerId) {
+    public List<TenantRequestResponse> getTenantRequestList(@RequestHeader("userId") Long ownerId) {
         return houseService.getTenantRequestList(ownerId);
     }
 
     // 집주인 승인
     @PostMapping("/tenant-approve/{houseId}")
     public ResponseEntity<Void> tenantApprove(@PathVariable Long houseId,
-            /*@RequestHeader("userId")*/ @RequestParam Long ownerId) {
+            @RequestHeader("userId") Long ownerId) {
         houseService.approveTenant(houseId, ownerId);
         return ResponseEntity.ok().build();
     }
@@ -64,7 +64,7 @@ public class HouseController {
     // 집주인 거절
     @PostMapping("/tenant-reject/{houseId}")
     public ResponseEntity<Void> tenantReject(@PathVariable Long houseId,
-            /*@RequestHeader("userId")*/ @RequestParam Long ownerId) {
+            @RequestHeader("userId") Long ownerId) {
         houseService.rejectTenant(houseId, ownerId);
         return ResponseEntity.ok().build();
     }

--- a/hotketok-house-service/src/main/resources/application-local.yml
+++ b/hotketok-house-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8087
+  port: 8090
 
 spring:
   application:
@@ -48,6 +48,6 @@ logging:
 
 client:
   user-service:
-    url: http://localhost:8084 # user-service의 주소
+    url: http://localhost:8088 # user-service의 주소
   infra-service:
-    url: http://localhost:8081 # infra-service의 주소
+    url: http://localhost:8089 # infra-service의 주소

--- a/hotketok-infra-service/src/main/resources/application-local.yml
+++ b/hotketok-infra-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8081
+  port: 8089
 
 spring:
   application:

--- a/hotketok-requestform-service/src/main/resources/application-local.yml
+++ b/hotketok-requestform-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8083
+  port: 8093
 
 spring:
   application:
@@ -63,5 +63,5 @@ openai:
 
 client:
   infra-service:
-    url: http://localhost:8081 # infra-service의 주소
+    url: http://localhost:8089 # infra-service의 주소
 

--- a/hotketok-user-service/src/main/resources/application-local.yml
+++ b/hotketok-user-service/src/main/resources/application-local.yml
@@ -1,5 +1,5 @@
 server:
-  port: 8084
+  port: 8088
 
 spring:
   application:


### PR DESCRIPTION
## 🌱 관련 이슈

- close #34 

---
## 📌 작업 내용 및 특이사항

- 각 마이크로서비스에서 이용하는 API에서 사용자id를 헤더에서 가져오도록 수정하였습니다.
- API-Gateway에 임시적으로 모든 마이크로 서비스를 라우팅 연결해서 API 테스트하실때 8000번 포트로 테스트하면 됩니다.(그래야지 필터 적용되서 userId 가져올 수 있음)
- 전체 마이크로서비스 포트번호 컨벤션에 따라 수정했습니다. 
- 채팅서비스에 userId가 맞는지 확인 바랍니다.

---
## 📚 참고사항

-