### PR TITLE
[feat]  수리요청서 정보 조회 기능 및 진행 중인 수리요청서 조회 API 개발

### DIFF
--- a/hotketok-house-service/src/main/java/com/hotketok/internalApi/HouseInternalController.java
+++ b/hotketok-house-service/src/main/java/com/hotketok/internalApi/HouseInternalController.java
@@ -39,4 +39,11 @@ public class HouseInternalController {
                                                                @RequestParam("number") String number) {
         return houseService.getHouseInfoByAddress(userId,role,address,number);
     }
+
+    @GetMapping("/get-ownerId/{userId}")
+    public Long getOwnerId(@PathVariable("userId") Long userId,
+                          @RequestParam("address") String address,
+                          @RequestParam("number") String number) {
+        return houseService.getOwnerId(userId,address,number);
+    }
 }

--- a/hotketok-house-service/src/main/java/com/hotketok/service/HouseService.java
+++ b/hotketok-house-service/src/main/java/com/hotketok/service/HouseService.java
@@ -170,5 +170,12 @@ public class HouseService {
         }
         return new GetHouseInfoByAddressResponse(address,number,house.getState().toString());
     }
+
+    @Transactional(readOnly = true)
+    public Long getOwnerId(Long userId, String currentAddress, String currentNumber){
+        House house = houseRepository.findByAddressAndNumberAndTenantId(currentAddress, currentNumber, userId)
+                .orElseThrow(() -> new CustomException(HouseErrorCode.HOUSE_NOT_FOUND));
+        return house.getOwnerId();
+    }
 }
 

--- a/hotketok-requestform-service/src/main/java/com/hotketok/domain/RequestForm.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/domain/RequestForm.java
@@ -43,6 +43,9 @@ public class RequestForm extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Status status; // 요청서 상태
 
+    private String address;
+
+    private String number;
 
     @Builder(access = AccessLevel.PRIVATE)
     private RequestForm(
@@ -52,7 +55,9 @@ public class RequestForm extends BaseTimeEntity {
             String description,
             LocalDateTime requestSchedule,
             Category category,
-            Status status){
+            Status status,
+            String address,
+            String number){
         this.authorId = authorId;
         this.payerId = payerId;
         this.payType = payType;
@@ -60,25 +65,35 @@ public class RequestForm extends BaseTimeEntity {
         this.requestSchedule = requestSchedule;
         this.category = category;
         this.status = status;
+        this.address = address;
+        this.number = number;
     }
 
     public static RequestForm createRequestForm(
-            Long authorId,
-            Long payerId,
             PayType payType,
             String description,
             LocalDateTime requestSchedule,
             Category category,
-            Status status
+            Status status,
+            String address,
+            String number
             ) {
         return RequestForm.builder()
-                .authorId(authorId)
-                .payerId(payerId)
+                .authorId(null)
+                .payerId(null)
                 .payType(payType)
                 .description(description)
                 .requestSchedule(requestSchedule)
                 .category(category)
                 .status(status)
+                .address(address)
+                .number(number)
                 .build();
     }
+
+    public void setAuthorIdAndPayerId(Long authorId, Long payerId) {
+        this.authorId = authorId;
+        this.payerId = payerId;
+    }
+
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/CreateRequestFormRequest.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/CreateRequestFormRequest.java
@@ -9,6 +9,8 @@ public record CreateRequestFormRequest(
         PayType payType,
         Category category,
         String description,
-        LocalDateTime requestSchedule
+        LocalDateTime requestSchedule,
+        String address,
+        String number
 ) {
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/GetUserInfoResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/GetUserInfoResponse.java
@@ -1,8 +1,0 @@
-package com.hotketok.dto;
-
-public record GetUserInfoResponse(
-        Long userId,
-        Long proprietorId,
-        String address
-) {
-}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/InProgressRequestFormResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/InProgressRequestFormResponse.java
@@ -1,0 +1,51 @@
+package com.hotketok.dto;
+
+import com.hotketok.domain.RequestForm;
+import com.hotketok.domain.enums.Category;
+import com.hotketok.domain.enums.PayType;
+import com.hotketok.domain.enums.Status;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+// 진행중인 수리 요청서 조회 API 응답값
+public record InProgressRequestFormResponse(
+        int count,
+        List<InProgressRequestFormInfo> list
+) {
+    public record InProgressRequestFormInfo(
+            Long requestFormId,
+            Category category,
+            LocalDateTime requestSchedule,
+            PayType payType,
+            Status status,
+            String number
+    ){
+    }
+
+    public static InProgressRequestFormResponse fromOwner(List<RequestForm> requestForms) {
+        List<InProgressRequestFormInfo> list = requestForms.stream()
+                .map(requestForm -> new InProgressRequestFormInfo(
+                        requestForm.getId(),
+                        requestForm.getCategory(),
+                        requestForm.getRequestSchedule(),
+                        requestForm.getPayType(),
+                        requestForm.getStatus(),
+                        requestForm.getNumber()
+                )).toList();
+        return new InProgressRequestFormResponse(requestForms.size(),list);
+    }
+
+    public static InProgressRequestFormResponse fromTenant(List<RequestForm> requestForms) {
+        List<InProgressRequestFormInfo> list = requestForms.stream()
+                .map(requestForm -> new InProgressRequestFormInfo(
+                        requestForm.getId(),
+                        requestForm.getCategory(),
+                        requestForm.getRequestSchedule(),
+                        requestForm.getPayType(),
+                        requestForm.getStatus(),
+                        null
+                )).toList();
+        return new InProgressRequestFormResponse(requestForms.size(),list);
+    }
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/RequestFormInfoResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/RequestFormInfoResponse.java
@@ -1,0 +1,18 @@
+package com.hotketok.dto;
+
+import com.hotketok.domain.enums.Category;
+import com.hotketok.domain.enums.PayType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RequestFormInfoResponse(
+        Category category,
+        LocalDateTime requestSchedule,
+        String currentAddress,
+        String currentNumber,
+        PayType payType,
+        List<String> imagesUrl,
+        String description
+) {
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/internalApi/CurrentAddressAndNumberResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/internalApi/CurrentAddressAndNumberResponse.java
@@ -1,0 +1,7 @@
+package com.hotketok.dto.internalApi;
+
+public record CurrentAddressAndNumberResponse(
+        String currentAddress,
+        String currentNumber
+) {
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
@@ -36,6 +36,11 @@ public class RequestFormController {
     RequestFormInfoResponse getRequestFormInfo(@PathVariable("requestformId") Long requestformId){
         return requestFormService.getRequestFormInfo(requestformId);
     }
-
+    // 진행중인 수리 확인
+    @GetMapping(value = "/in-progress")
+    InProgressRequestFormResponse getInProgressRequestForm(@RequestHeader("userId") Long userId,
+                                                           @RequestHeader("role") String role){
+        return requestFormService.getInProgressRequestForm(userId,role);
+    }
 
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
@@ -1,9 +1,6 @@
 package com.hotketok.externalApi;
 
-import com.hotketok.dto.ChatGPTResponse;
-import com.hotketok.dto.CreateRequestFormRequest;
-import com.hotketok.dto.CreateRequestFormResponse;
-import com.hotketok.dto.RequestFormInfoResponse;
+import com.hotketok.dto.*;
 import com.hotketok.service.RequestFormService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -18,7 +15,7 @@ import java.util.List;
 public class RequestFormController {
 
     private final RequestFormService requestFormService;
-
+    // 요청서 작성
     @PostMapping(value = "/create", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     CreateRequestFormResponse createRequestForm(
             @RequestHeader("userId") Long userId,
@@ -27,12 +24,18 @@ public class RequestFormController {
 
         return requestFormService.createRequestForm(createRequestFormRequest,images,userId);
     }
-
+    // 요청서 도우미 (사진 인식으로 설명 작성 도우미)
     @PostMapping(value = "/gpt-service", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ChatGPTResponse helpDescriptionByGPT(
             @RequestPart(value = "images") List<MultipartFile> images
     ) throws Exception {
        return requestFormService.helpDescriptionByGPT(images);
     }
+    // 수리 요청서 정보 확인
+    @GetMapping(value = "/requestform-info/{requestformId}")
+    RequestFormInfoResponse getRequestFormInfo(@PathVariable("requestformId") Long requestformId){
+        return requestFormService.getRequestFormInfo(requestformId);
+    }
+
 
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
@@ -3,10 +3,10 @@ package com.hotketok.externalApi;
 import com.hotketok.dto.ChatGPTResponse;
 import com.hotketok.dto.CreateRequestFormRequest;
 import com.hotketok.dto.CreateRequestFormResponse;
+import com.hotketok.dto.RequestFormInfoResponse;
 import com.hotketok.service.RequestFormService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 

--- a/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/HouseServiceClient.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/HouseServiceClient.java
@@ -1,0 +1,13 @@
+package com.hotketok.internalApi;
+
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient(name = "house-service", url = "${client.house-service.url}")
+public interface HouseServiceClient {
+
+    @GetMapping("/get-ownerId/{userId}")
+    Long getOwnerId(@PathVariable("userId") Long userId, @RequestParam("address") String address, @RequestParam("number") String number);
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/HouseServiceClient.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/HouseServiceClient.java
@@ -8,6 +8,6 @@ import org.springframework.web.bind.annotation.RequestParam;
 @FeignClient(name = "house-service", url = "${client.house-service.url}")
 public interface HouseServiceClient {
 
-    @GetMapping("/get-ownerId/{userId}")
+    @GetMapping("/internal/house-service/get-ownerId/{userId}")
     Long getOwnerId(@PathVariable("userId") Long userId, @RequestParam("address") String address, @RequestParam("number") String number);
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/UserServiceClient.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/UserServiceClient.java
@@ -1,0 +1,13 @@
+package com.hotketok.internalApi;
+
+import com.hotketok.dto.internalApi.CurrentAddressAndNumberResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+@FeignClient(name = "user-service", url = "${client.user-service.url}")
+public interface UserServiceClient {
+
+    @GetMapping("/internal/user-service/current-address-and-number/{userId}")
+    CurrentAddressAndNumberResponse getCurrentAddressAndNumber(@PathVariable("userId") Long userId);
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormImageRepository.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormImageRepository.java
@@ -7,4 +7,5 @@ import java.util.List;
 
 public interface RequestFormImageRepository extends JpaRepository<RequestFormImage, Long> {
     void deleteAllByIdIn(List<Long> RequestFormImageIds);
+    List<RequestFormImage> findAllByRequestFormId(Long requestFormId);
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormRepository.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormRepository.java
@@ -1,7 +1,12 @@
 package com.hotketok.repository;
 
 import com.hotketok.domain.RequestForm;
+import com.hotketok.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface RequestFormRepository extends JpaRepository<RequestForm, Long> {
+    List<RequestForm> findAllByAddressAndNumberAndStatusNot(String address, String number, Status status);
+    List<RequestForm> findAllByAddressAndStatusNot(String address, Status status);
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
@@ -3,9 +3,11 @@ package com.hotketok.service;
 import com.hotketok.constant.GPTPrompt;
 import com.hotketok.domain.enums.PayType;
 import com.hotketok.dto.*;
+import com.hotketok.dto.internalApi.CurrentAddressAndNumberResponse;
 import com.hotketok.dto.internalApi.UploadFileListResponse;
 import com.hotketok.exception.RequestFormErrorCode;
 import com.hotketok.hotketokcommonservice.error.exception.CustomException;
+import com.hotketok.hotketokcommonservice.error.exception.GlobalErrorCode;
 import com.hotketok.internalApi.HouseServiceClient;
 import com.hotketok.internalApi.UserServiceClient;
 import com.hotketok.parser.OpenAIResponseParser;
@@ -142,4 +144,25 @@ public class RequestFormService {
 
         return new ChatGPTResponse(textOnly);
     }
+
+    // 요청서 조회
+    public RequestFormInfoResponse getRequestFormInfo(Long requestFormId){
+        RequestForm requestForm = requestFormRepository.findById(requestFormId)
+                .orElseThrow(() -> new CustomException(RequestFormErrorCode.REQUEST_FORM_NOT_FOUND));
+
+        List<String> images = requestFormImageRepository
+                .findAllByRequestFormId(requestFormId)
+                .stream().map(RequestFormImage::getImageUrl).toList();
+
+        return new RequestFormInfoResponse(
+                requestForm.getCategory(),
+                requestForm.getRequestSchedule(),
+                requestForm.getAddress(),
+                requestForm.getNumber(),
+                requestForm.getPayType(),
+                images,
+                requestForm.getDescription()
+        );
+    }
+
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
@@ -1,15 +1,17 @@
 package com.hotketok.service;
 
 import com.hotketok.constant.GPTPrompt;
-import com.hotketok.dto.CreateRequestFormResponse;
+import com.hotketok.domain.enums.PayType;
+import com.hotketok.dto.*;
 import com.hotketok.dto.internalApi.UploadFileListResponse;
+import com.hotketok.exception.RequestFormErrorCode;
+import com.hotketok.hotketokcommonservice.error.exception.CustomException;
+import com.hotketok.internalApi.HouseServiceClient;
+import com.hotketok.internalApi.UserServiceClient;
 import com.hotketok.parser.OpenAIResponseParser;
 import com.hotketok.domain.RequestForm;
 import com.hotketok.domain.RequestFormImage;
 import com.hotketok.domain.enums.Status;
-import com.hotketok.dto.ChatGPTResponse;
-import com.hotketok.dto.CreateRequestFormRequest;
-import com.hotketok.dto.GetUserInfoResponse;
 import com.hotketok.internalApi.InfraServiceClient;
 import com.hotketok.internalApi.OpenAiClient;
 import com.hotketok.repository.RequestFormImageRepository;
@@ -36,30 +38,35 @@ public class RequestFormService {
     private final RequestFormImageRepository requestFormImageRepository;
     private final InfraServiceClient infraServiceClient;
     private final OpenAiClient openAiClient;
+    private final UserServiceClient userServiceClient;
+    private final HouseServiceClient houseServiceClient;
 
     @Value("${openai.model}")
     private String model;
 
+    // 요청서 생성
     @Transactional
     public CreateRequestFormResponse createRequestForm(
             CreateRequestFormRequest createRequestFormRequest,
             List<MultipartFile> images,
             Long userId) {
 
-        // 사용자 서비스에서 주택주소, authorId, payerId 가져오는 서비스 로직
-        // GetUserInfoResponse getUserInfoResponse = memberClient.getUserInfoByPayType(userId,createRequestFormRequest.payType());
-
-        GetUserInfoResponse getUserInfoResponse = new GetUserInfoResponse(userId, 2L, "동작 핫케톡 스테이 304호");
-
         RequestForm requestForm = RequestForm.createRequestForm(
-                getUserInfoResponse.userId(),
-                getUserInfoResponse.proprietorId(),
                 createRequestFormRequest.payType(),
                 createRequestFormRequest.description(),
                 createRequestFormRequest.requestSchedule(),
                 createRequestFormRequest.category(),
-                Status.CHOOSING
+                Status.CHOOSING,
+                createRequestFormRequest.address(),
+                createRequestFormRequest.number()
         );
+
+        if (createRequestFormRequest.payType().equals(PayType.PROPRIETORSHIP)){
+            Long ownerId = houseServiceClient.getOwnerId(userId, requestForm.getAddress(), requestForm.getNumber());
+            requestForm.setAuthorIdAndPayerId(userId, ownerId);
+        }else {
+            requestForm.setAuthorIdAndPayerId(userId, userId);
+        }
 
         boolean isImageSaved = false;
         List<Long> imageIds = new ArrayList<>();
@@ -88,6 +95,7 @@ public class RequestFormService {
         }
     }
 
+    // 요청서 설명 도우미 (GPT)
     public ChatGPTResponse helpDescriptionByGPT(List<MultipartFile> images) throws Exception {
         UploadFileListResponse uploadFileListResponse = infraServiceClient.uploadImages(images, "requestform-ai/");
 

--- a/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
@@ -165,4 +165,20 @@ public class RequestFormService {
         );
     }
 
+    // 진행중인 수리요청서 조회
+    public InProgressRequestFormResponse getInProgressRequestForm(Long userId, String role){
+        CurrentAddressAndNumberResponse addressAndNumber = userServiceClient.getCurrentAddressAndNumber(userId);
+        if (role.equals("OWNER")){
+            List<RequestForm> requestForms = requestFormRepository
+                    .findAllByAddressAndStatusNot(addressAndNumber.currentAddress(), Status.COMPLETED);
+            return InProgressRequestFormResponse.fromOwner(requestForms);
+
+        } else if(role.equals("TENANT")){
+            List<RequestForm> requestForms = requestFormRepository
+                    .findAllByAddressAndNumberAndStatusNot(addressAndNumber.currentAddress(), addressAndNumber.currentNumber(), Status.COMPLETED);
+            return InProgressRequestFormResponse.fromTenant(requestForms);
+        } else{
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+    }
 }

--- a/hotketok-requestform-service/src/main/resources/application-local.yml
+++ b/hotketok-requestform-service/src/main/resources/application-local.yml
@@ -64,4 +64,8 @@ openai:
 client:
   infra-service:
     url: http://localhost:8089 # infra-service의 주소
+  user-service:
+    url: http://localhost:8088 # user-service의 주소
+  house-service:
+    url: http://localhost:8090 # house-service의 주소
 

--- a/hotketok-user-service/src/main/java/com/hotketok/dto/internalApi/CurrentAddressAndNumberResponse.java
+++ b/hotketok-user-service/src/main/java/com/hotketok/dto/internalApi/CurrentAddressAndNumberResponse.java
@@ -1,0 +1,7 @@
+package com.hotketok.dto.internalApi;
+
+public record CurrentAddressAndNumberResponse(
+        String currentAddress,
+        String currentNumber
+) {
+}

--- a/hotketok-user-service/src/main/java/com/hotketok/externalApi/UserController.java
+++ b/hotketok-user-service/src/main/java/com/hotketok/externalApi/UserController.java
@@ -3,6 +3,7 @@ package com.hotketok.externalApi;
 import com.hotketok.dto.ChangeCurrentAddressRequest;
 import com.hotketok.dto.MyPageInfoResponse;
 import com.hotketok.dto.UpdateMyPageInfoRequest;
+import com.hotketok.dto.internalApi.CurrentAddressAndNumberResponse;
 import com.hotketok.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
@@ -39,5 +40,10 @@ public class UserController {
     ){
         userService.updateCurrentAddressAndNumber(userId, request.currentAddress(), request.currentNumber());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/current-address-and-number")
+    public CurrentAddressAndNumberResponse getCurrentAddressAndNumber(@RequestHeader("userId") Long userId){
+        return userService.getCurrentAddressAndNumberByUserId(userId);
     }
 }

--- a/hotketok-user-service/src/main/java/com/hotketok/internalApi/UserInternalController.java
+++ b/hotketok-user-service/src/main/java/com/hotketok/internalApi/UserInternalController.java
@@ -1,6 +1,7 @@
 package com.hotketok.internalApi;
 
 // 채팅 서비스에서 호출하는 컨트롤러
+import com.hotketok.dto.internalApi.CurrentAddressAndNumberResponse;
 import com.hotketok.dto.internalApi.CurrentAddressResponse;
 import com.hotketok.dto.internalApi.UserProfileResponse;
 import com.hotketok.service.UserService;
@@ -48,6 +49,11 @@ public class UserInternalController {
     public CurrentAddressResponse getCurrentAddress(@PathVariable Long userId) {
         String address = userService.getCurrentAddressByUserId(userId);
         return new CurrentAddressResponse(address);
+    }
+
+    @GetMapping ("/current-address-and-number/{userId}")
+    public CurrentAddressAndNumberResponse getCurrentAddressAndNumber(@PathVariable Long userId) {
+        return userService.getCurrentAddressAndNumberByUserId(userId);
     }
 }
 

--- a/hotketok-user-service/src/main/java/com/hotketok/service/UserService.java
+++ b/hotketok-user-service/src/main/java/com/hotketok/service/UserService.java
@@ -1,10 +1,7 @@
 package com.hotketok.service;
 
 import com.hotketok.dto.*;
-import com.hotketok.dto.internalApi.GetHouseInfoByAddressResponse;
-import com.hotketok.dto.internalApi.MyPageHouseInfoResponse;
-import com.hotketok.dto.internalApi.UploadFileResponse;
-import com.hotketok.dto.internalApi.UserProfileResponse;
+import com.hotketok.dto.internalApi.*;
 import com.hotketok.internalApi.HouseServiceClient;
 import com.hotketok.internalApi.InfraServiceClient;
 import com.hotketok.repository.UserRepository;
@@ -113,5 +110,11 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
         return user.getCurrentAddress();
+    }
+
+    public CurrentAddressAndNumberResponse getCurrentAddressAndNumberByUserId(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(UserErrorCode.USER_NOT_FOUND));
+        return new CurrentAddressAndNumberResponse(user.getCurrentAddress(), user.getCurrentNumber());
     }
 }


### PR DESCRIPTION
## 🌱 관련 이슈

- close #20 

---
## 📌 작업 내용 및 특이사항

- 사용자 id를 통해 사용자의 현재 주소와 호수를 가져오도록 하는 내부 API 개발
- 요청서 생성 API 수정
- 수리요청서 정보 조회 API 개발
- 진행중인 수리요청서 조회 API 개발
- <Strong> 수리 상세보기 페이지에 견적서 정보와 수리요청서 정보를 합쳐야됩니다. </Strong>

---
## 📚 참고사항

-