### PR TITLE
[feat] 완료된 수리요청서 년도별 조회 API 개발

### DIFF
--- a/hotketok-estimate-service/src/main/java/com/hotketok/dto/internalApi/EstimatePriceResponse.java
+++ b/hotketok-estimate-service/src/main/java/com/hotketok/dto/internalApi/EstimatePriceResponse.java
@@ -1,0 +1,8 @@
+package com.hotketok.dto.internalApi;
+
+import java.math.BigDecimal;
+
+public record EstimatePriceResponse(
+        BigDecimal estimatePrice
+) {
+}

--- a/hotketok-estimate-service/src/main/java/com/hotketok/internalApi/EstimateInternalController.java
+++ b/hotketok-estimate-service/src/main/java/com/hotketok/internalApi/EstimateInternalController.java
@@ -2,6 +2,7 @@ package com.hotketok.internalApi;
 
 import com.hotketok.domain.enums.Status;
 import com.hotketok.dto.internalApi.EstimateInfoResponse;
+import com.hotketok.dto.internalApi.EstimatePriceResponse;
 import com.hotketok.dto.internalApi.EstimateStatusCountResponse;
 import com.hotketok.dto.internalApi.SimpleEstimateResponse;
 import com.hotketok.service.EstimateService;
@@ -35,6 +36,12 @@ public class EstimateInternalController {
     public SimpleEstimateResponse getEstimateById(@PathVariable Long estimateId) {
         return estimateService.findSimpleEstimateById(estimateId);
     }
+
+    @GetMapping("/estimate-price/{requestFormId}")
+    public EstimatePriceResponse getEstimatePriceByRequestFormId(@PathVariable Long requestFormId){
+        return estimateService.findEstimatePriceByRequestFormId(requestFormId);
+    }
+
 
     @GetMapping("/counts")
     public EstimateStatusCountResponse getEstimateCounts(@RequestParam Long vendorId) {

--- a/hotketok-estimate-service/src/main/java/com/hotketok/repository/EstimateRepository.java
+++ b/hotketok-estimate-service/src/main/java/com/hotketok/repository/EstimateRepository.java
@@ -5,9 +5,11 @@ import com.hotketok.domain.enums.Status;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EstimateRepository extends JpaRepository<Estimate, Long> {
     List<Estimate> findAllByRequestFormId(Long requestFormId);
+    Optional<Estimate> findByRequestFormId(Long requestFormId);
     List<Estimate> findAllByVendorId(Long vendorId);
     List<Estimate> findAllByVendorIdAndStatus(Long vendorId, Status status);
     long countByVendorIdAndStatus(Long vendorId, Status status);

--- a/hotketok-estimate-service/src/main/java/com/hotketok/service/EstimateService.java
+++ b/hotketok-estimate-service/src/main/java/com/hotketok/service/EstimateService.java
@@ -176,4 +176,10 @@ public class EstimateService {
                 requestFormIds
         );
     }
+
+    // 요청서 id를 통한 견적서 금액 확인 (지난 수리요청서 조회 API를 위한 내부 API)
+    public EstimatePriceResponse findEstimatePriceByRequestFormId(Long requestFormId) {
+        Estimate estimate = estimateRepository.findByRequestFormId(requestFormId).orElseThrow(() -> new CustomException(EstimateErrorCode.ESTIMATE_NOT_FOUND));
+        return new EstimatePriceResponse(estimate.getEstimatePrice());
+    }
 }

--- a/hotketok-estimate-service/src/main/java/com/hotketok/service/EstimateService.java
+++ b/hotketok-estimate-service/src/main/java/com/hotketok/service/EstimateService.java
@@ -44,6 +44,7 @@ public class EstimateService {
                 request.decisionLater(),
                 request.comment()
         );
+        requestFormClient.updateRequestFormStatus(request.requestFormId(), new UpdateStatusRequest(Status.CHOOSING));
         Estimate savedEstimate = estimateRepository.save(estimate);
 
         // 반환에는 주소, 카테고리 포함

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/CompletedRequestFormResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/CompletedRequestFormResponse.java
@@ -1,0 +1,15 @@
+package com.hotketok.dto;
+
+import com.hotketok.domain.enums.ConstructCategory;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record CompletedRequestFormResponse(
+        Long requestFormId,
+        ConstructCategory category,
+        LocalDateTime requestSchedule,
+        BigDecimal estimatePrice,
+        String number
+) {
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/dto/internalApi/EstimatePriceResponse.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/dto/internalApi/EstimatePriceResponse.java
@@ -1,0 +1,8 @@
+package com.hotketok.dto.internalApi;
+
+import java.math.BigDecimal;
+
+public record EstimatePriceResponse(
+        BigDecimal estimatePrice
+) {
+}

--- a/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/externalApi/RequestFormController.java
@@ -43,4 +43,12 @@ public class RequestFormController {
         return requestFormService.getInProgressRequestForm(userId,role);
     }
 
+    // 완료된 수리 확인
+    @GetMapping(value = "/completed")
+    List<CompletedRequestFormResponse> getCompletedRequestForm(@RequestHeader("userId") Long userId,
+                                                         @RequestHeader("role") String role,
+                                                         @RequestParam("year") int year){
+        return requestFormService.getCompletedRequestForm(userId, role, year);
+    }
+
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/EstimateServiceClient.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/internalApi/EstimateServiceClient.java
@@ -1,8 +1,10 @@
 package com.hotketok.internalApi;
 
 import com.hotketok.dto.internalApi.EstimateInfoResponse;
+import com.hotketok.dto.internalApi.EstimatePriceResponse;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
@@ -11,4 +13,7 @@ import java.util.List;
 public interface EstimateServiceClient {
     @GetMapping("/internal/estimate-service")
     List<EstimateInfoResponse> getEstimatesByRequestFormId(@RequestParam("requestFormId") Long requestFormId);
+
+    @GetMapping("/internal/estimate-service/estimate-price/{requestFormId}")
+    EstimatePriceResponse getEstimatePriceByRequestFormId(@PathVariable Long requestFormId);
 }

--- a/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormRepository.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/repository/RequestFormRepository.java
@@ -8,8 +8,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public interface RequestFormRepository extends JpaRepository<RequestForm, Long> {
+    // 진행중인 수리요청서 확인
     List<RequestForm> findAllByAddressAndNumberAndStatusNot(String address, String number, Status status);
     List<RequestForm> findAllByAddressAndStatusNot(String address, Status status);
+    // 완료된 수리요청서 확인
+    List<RequestForm> findAllByAddressAndStatus(String address, Status status);
+    List<RequestForm> findAllByAddressAndNumberAndStatus(String address, String number, Status status);
+
     List<RequestForm> findAllByIdIn(List<Long> requestFormId);
     List<RequestForm> findAllByStatusIn(List<Status> statuses);
     List<RequestForm> findAllByIdInAndRequestScheduleBetween(List<Long> ids, LocalDateTime start, LocalDateTime end);

--- a/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
@@ -13,14 +13,11 @@ import com.hotketok.hotketokcommonservice.error.exception.CustomException;
 import com.hotketok.domain.enums.PayType;
 import com.hotketok.dto.*;
 import com.hotketok.hotketokcommonservice.error.exception.GlobalErrorCode;
-import com.hotketok.internalApi.HouseServiceClient;
-import com.hotketok.internalApi.UserServiceClient;
+import com.hotketok.internalApi.*;
 import com.hotketok.parser.OpenAIResponseParser;
 import com.hotketok.domain.RequestForm;
 import com.hotketok.domain.RequestFormImage;
 import com.hotketok.domain.enums.Status;
-import com.hotketok.internalApi.InfraServiceClient;
-import com.hotketok.internalApi.OpenAiClient;
 import com.hotketok.repository.RequestFormImageRepository;
 import com.hotketok.repository.RequestFormRepository;
 import feign.FeignException;
@@ -51,6 +48,7 @@ public class RequestFormService {
     private final OpenAiClient openAiClient;
     private final UserServiceClient userServiceClient;
     private final HouseServiceClient houseServiceClient;
+    private final EstimateServiceClient estimateServiceClient;
 
     @Value("${openai.model}")
     private String model;
@@ -190,6 +188,47 @@ public class RequestFormService {
             throw new CustomException(GlobalErrorCode.BAD_REQUEST);
         }
     }
+
+    // 완료된 수리요청서 조회
+    public List<CompletedRequestFormResponse> getCompletedRequestForm(Long userId, String role, int year){
+        CurrentAddressAndNumberResponse addressAndNumber = userServiceClient.getCurrentAddressAndNumber(userId);
+        List<CompletedRequestFormResponse> result;
+        if (role.equals("OWNER")){
+            List<RequestForm> requestForms = requestFormRepository
+                    .findAllByAddressAndStatus(addressAndNumber.currentAddress(), Status.COMPLETED);
+            result = requestForms.stream().map(requestForm -> {
+                EstimatePriceResponse estimatePriceByRequestFormId =
+                        estimateServiceClient.getEstimatePriceByRequestFormId(requestForm.getId());
+                return new CompletedRequestFormResponse(
+                        requestForm.getId(),
+                        requestForm.getCategory(),
+                        requestForm.getRequestSchedule(),
+                        estimatePriceByRequestFormId.estimatePrice(),
+                        requestForm.getNumber());
+            }).collect(Collectors.toList());
+            return result;
+
+        } else if(role.equals("TENANT")){
+            List<RequestForm> requestForms = requestFormRepository
+                    .findAllByAddressAndNumberAndStatus(addressAndNumber.currentAddress(), addressAndNumber.currentNumber(), Status.COMPLETED);
+
+            result = requestForms.stream().map(requestForm -> {
+                EstimatePriceResponse estimatePriceByRequestFormId =
+                        estimateServiceClient.getEstimatePriceByRequestFormId(requestForm.getId());
+                return new CompletedRequestFormResponse(
+                        requestForm.getId(),
+                        requestForm.getCategory(),
+                        requestForm.getRequestSchedule(),
+                        estimatePriceByRequestFormId.estimatePrice(),
+                        null);
+            }).collect(Collectors.toList());
+            return result;
+        } else{
+            throw new CustomException(GlobalErrorCode.BAD_REQUEST);
+        }
+    }
+
+
     public RequestFormDataResponse getRequestFormDataById(Long requestFormId) {
         RequestForm requestForm = requestFormRepository.findById(requestFormId)
                 .orElseThrow(() -> new CustomException(RequestFormErrorCode.REQUEST_FORM_NOT_FOUND));

--- a/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
+++ b/hotketok-requestform-service/src/main/java/com/hotketok/service/RequestFormService.java
@@ -65,7 +65,7 @@ public class RequestFormService {
                 createRequestFormRequest.description(),
                 createRequestFormRequest.requestSchedule(),
                 createRequestFormRequest.category(),
-                Status.CHOOSING,
+                Status.SEARCHING,
                 createRequestFormRequest.address(),
                 createRequestFormRequest.number()
         );


### PR DESCRIPTION
## 🌱 관련 이슈

- close #105 

---
## 📌 작업 내용 및 특이사항

- 완료된 수리요청서 년도별 조회 API 개발
- 수리요청서 생성 시 Status -> Searching, 견적서 생성 시 요청서 Status -> Choosing 으로 로직 수정

---
## 📚 참고사항

-